### PR TITLE
Fix npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "mocha test/unit/index.js --compilers js:babel-register",
     "build": "babel src/ -d dist/",
-    "release": "browserify src/ -o funnies.min.js -t [babelify] -t [uglifyify]",
+    "release": "browserify src/index.js -o funnies.min.js -t [babelify] -t [uglifyify]",
     "prepublish": "npm run build && npm run release"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "Make user's laugh when your app is loading.",
   "main": "dist/index.js",
   "scripts": {
-    "test": "./node_modules/.bin/mocha test/unit/index.js --compilers js:babel-register",
-    "build": "./node_modules/.bin/babel src/ -d dist/",
-    "release": "./node_modules/.bin/browserify src/ -o funnies.min.js -t [babelify] -t [uglifyify]",
+    "test": "mocha test/unit/index.js --compilers js:babel-register",
+    "build": "babel src/ -d dist/",
+    "release": "browserify src/ -o funnies.min.js -t [babelify] -t [uglifyify]",
     "prepublish": "npm run build && npm run release"
   },
   "repository": {


### PR DESCRIPTION
Noted my issue in #23 😸 

The awesome thing with npm scripts is that you don't have to reference the `node_modules/.bin` directory as it's added to Path whenever you use `npm run <script>` (See: https://docs.npmjs.com/misc/scripts#path)

Changes:
- Tidy up node module references in npm scripts
- Add entry point for browserify so it validly bundles 

With these changes, `funnies.min.js` seems to bundle correctly and not throw any errors in chrome. 