### PR TITLE
allow setting the classname of the wrapper component

### DIFF
--- a/src/react.js
+++ b/src/react.js
@@ -24,14 +24,14 @@ export default class FunniesComponent extends React.Component {
     }
   }
   render() {
-    return <div className="funnies">
+    return <div className={this.props.className || 'funnies'}>
       <ReactCSSTransitionGroup
         transitionName="funnies"
         transitionEnterTimeout={200}
         transitionLeaveTimeout={200}
       >
         <span
-          className="funnies-text"
+          className={this.props.innerClassName || 'funnies-text'}
           key={this.state.message}
         >{this.state.message}</span>
       </ReactCSSTransitionGroup>


### PR DESCRIPTION
With this change, users can specify a classname for the outside and inside wrappers of the component.